### PR TITLE
Adding ISO 8601 datetime format.

### DIFF
--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Abstractions\MessagingException.cs" />
     <Compile Include="ServiceBus\ServiceBusLoggingExtensions.cs" />
     <Compile Include="ServiceBus\ServiceBusSenderPool.cs" />
+    <Compile Include="StringFormatConstants.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Helsenorge.Registries\Helsenorge.Registries.csproj">

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -124,7 +124,7 @@ namespace Helsenorge.Messaging.ServiceBus
 		}
 
 		private void SetValue(string key, string value) => _implementation.Properties[key] = value;
-		private void SetValue(string key, DateTime value) => _implementation.Properties[key] = value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssK");
+		private void SetValue(string key, DateTime value) => _implementation.Properties[key] = value.ToString(StringFormatConstants.IsoDateTime, DateTimeFormatInfo.InvariantInfo);
 		private void SetValue(string key, int value) => _implementation.Properties[key] = value.ToString(CultureInfo.InvariantCulture);
 
 		private string GetValue(string key, string value) => _implementation.Properties.ContainsKey(key) ? _implementation.Properties[key].ToString() : value;

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -124,7 +124,7 @@ namespace Helsenorge.Messaging.ServiceBus
 		}
 
 		private void SetValue(string key, string value) => _implementation.Properties[key] = value;
-		private void SetValue(string key, DateTime value) => _implementation.Properties[key] = value.ToString(DateTimeFormatInfo.InvariantInfo);
+		private void SetValue(string key, DateTime value) => _implementation.Properties[key] = value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssK");
 		private void SetValue(string key, int value) => _implementation.Properties[key] = value.ToString(CultureInfo.InvariantCulture);
 
 		private string GetValue(string key, string value) => _implementation.Properties.ContainsKey(key) ? _implementation.Properties[key].ToString() : value;

--- a/src/Helsenorge.Messaging/StringFormatConstants.cs
+++ b/src/Helsenorge.Messaging/StringFormatConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace Helsenorge.Messaging
+{
+	internal static class StringFormatConstants
+	{
+		/// <summary>
+		/// ISO 8601 compliant datetime format.
+		/// </summary>
+		public const string IsoDateTime = "yyyy'-'MM'-'dd'T'HH':'mm':'ssK";
+	}
+}


### PR DESCRIPTION
Fixes #2.

Using an explicit format string instead of the [standard "o" format](https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Roundtrip) for ISO 8601, to avoid second fractions. The string could be extracted to a string constant, but I couldn't find a suitable place for it, please let me know if this should be done and where to place the constant. 