### PR TITLE
Added "abuse:spoofing-attack" errorCondition

### DIFF
--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -90,6 +90,7 @@
     <Compile Include="MessagingClient.cs" />
     <Compile Include="MessagingServer.cs" />
     <Compile Include="ServiceBus\Receivers\HeaderValidationException.cs" />
+    <Compile Include="ServiceBus\Receivers\SenderHerIdMismatchException.cs" />
     <Compile Include="ServiceBus\ServiceBusFactoryPool.cs" />
     <Compile Include="ServiceBus\ServiceBusMessage.cs" />
     <Compile Include="Abstractions\ContentType.cs" />

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -197,6 +197,11 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
 				Core.ReportErrorToExternalSender(Logger, EventIds.ApplicationReported, message, "transport:internal-error", ex.Message, null, ex);
 				MessagingNotification.NotifyHandledException(message, ex);
 			}
+			catch (SenderHerIdMismatchException ex) // reportable error from message handler (application)
+			{
+				Core.ReportErrorToExternalSender(Logger, EventIds.DataMismatch, message, "abuse:spoofing-attack", ex.Message, null, ex);
+				MessagingNotification.NotifyHandledException(message, ex);
+			}
 			catch (Exception ex) // unknown error
 			{
 				message.AddDetailsToException(ex);

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/SenderHerIdMismatchException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/SenderHerIdMismatchException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Helsenorge.Messaging.ServiceBus.Receivers
+{
+	[Serializable]
+	public class SenderHerIdMismatchException : Exception
+	{
+		public SenderHerIdMismatchException()
+		{
+		}
+
+		public SenderHerIdMismatchException(string message) : base(message)
+		{
+		}
+
+		public SenderHerIdMismatchException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		protected SenderHerIdMismatchException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4 .

Added handling for mismatching sender HER-IDs. The message handler validates the HER-IDs and throws an exception when they don't match. ReceivedDataMismatchException resulted in a different error condition, which is why we created a new Exception type.