### PR TITLE
Error handling for synchronous reply messages

### DIFF
--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -78,6 +78,12 @@ namespace Helsenorge.Messaging
             }
 		}
 
+		/// <summary>
+		/// Registers a delegate that should be called when we receive a synchronous reply message. This is where the main reply message processing is done.
+		/// </summary>
+		/// <param name="action">The delegate that should be called</param>
+		public void RegisterSynchronousReplyMessageReceivedCallback(Action<IncomingMessage> action) => _synchronousServiceBusSender.OnSynchronousReplyMessageReceived = action;
+
 		private async Task<CollaborationProtocolMessage> PreCheck(ILogger logger, OutgoingMessage message)
 		{
 			if (message == null) throw new ArgumentNullException(nameof(message));

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/SynchronousReplyListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/SynchronousReplyListener.cs
@@ -23,7 +23,8 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
 		/// </summary>
 		/// <param name="core">Reference to core service bus infrastructure</param>
 		/// <param name="logger">Logger used for diagnostic purposes</param>
-		internal SynchronousReplyListener(ServiceBusCore core, ILogger logger) : base(core, logger, null)
+		/// <param name="messagingNotification"></param>
+		internal SynchronousReplyListener(ServiceBusCore core, ILogger logger, IMessagingNotification messagingNotification) : base(core, logger, messagingNotification)
 		{
 			ReadTimeout = Core.Settings.Synchronous.ReadTimeout;
 		}
@@ -54,7 +55,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
 		protected override void NotifyMessageProcessingReady(IMessagingMessage rawMessage, IncomingMessage message)
 		{
 			Logger.LogDebug("NotifyMessageProcessingReady");
-			// Not relevant for this implementation
+			MessagingNotification.NotifySynchronousMessageReceived(message);
 		}
 	}
 }

--- a/src/Helsenorge.Messaging/ServiceBus/Senders/SynchronousSender.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Senders/SynchronousSender.cs
@@ -12,7 +12,7 @@ namespace Helsenorge.Messaging.ServiceBus.Senders
 	/// <summary>
 	/// Handles synchronous sending
 	/// </summary>
-	internal class SynchronousSender
+	internal class SynchronousSender : IMessagingNotification
 	{
 		private readonly ConcurrentDictionary<string, MessageEntry> _pendingSynchronousRequests = new ConcurrentDictionary<string, MessageEntry>();
 
@@ -37,11 +37,13 @@ namespace Helsenorge.Messaging.ServiceBus.Senders
 			_core = core;
 		}
 
+		public Action<IncomingMessage> OnSynchronousReplyMessageReceived { get; set; }
+
 		public async Task<XDocument> SendAsync(ILogger logger, OutgoingMessage message)
 		{
 			await _core.Send(logger, message, QueueType.Synchronous, _core.Settings.Synchronous.FindReplyQueueForMe()).ConfigureAwait(false);
 
-			var listener = new SynchronousReplyListener(_core, logger);
+			var listener = new SynchronousReplyListener(_core, logger, this);
 			var start = DateTime.UtcNow;
 			var correlationId = message.MessageId;
 
@@ -159,6 +161,52 @@ namespace Helsenorge.Messaging.ServiceBus.Senders
 						entry.ReplyEnqueuedTimeUtc);
 				}
 			}
+		}
+
+		public void NotifyAsynchronousMessageReceived(IncomingMessage message)
+		{
+
+		}
+
+		public void NotifyAsynchronousMessageReceivedStarting(IncomingMessage message)
+		{
+
+		}
+
+		public void NotifyAsynchronousMessageReceivedCompleted(IncomingMessage message)
+		{
+
+		}
+
+		public void NotifyErrorMessageReceived(IMessagingMessage message)
+		{
+
+		}
+
+		public XDocument NotifySynchronousMessageReceived(IncomingMessage message)
+		{
+			OnSynchronousReplyMessageReceived?.Invoke(message);
+			return message.Payload;
+		}
+
+		public void NotifySynchronousMessageReceivedCompleted(IncomingMessage message)
+		{
+
+		}
+
+		public void NotifySynchronousMessageReceivedStarting(IncomingMessage message)
+		{
+
+		}
+
+		public void NotifyUnhandledException(IMessagingMessage message, Exception ex)
+		{
+
+		}
+
+		public void NotifyHandledException(IMessagingMessage message, Exception ex)
+		{
+
 		}
 	}
 }


### PR DESCRIPTION
Fixes #6.

Added hooks for handling incoming synchronous reply messages. As discussed, we could potentially split the IMessagingNotification interface as a first refactoring step, and reduce the number of empty methods in SynchronousSender.