### PR TITLE
Turn off online CRL check

### DIFF
--- a/src/Helsenorge.Messaging/MessagingCore.cs
+++ b/src/Helsenorge.Messaging/MessagingCore.cs
@@ -59,7 +59,7 @@ namespace Helsenorge.Messaging
 			CollaborationProtocolRegistry = collaborationProtocolRegistry;
 			AddressRegistry = addressRegistry;
 
-			DefaultCertificateValidator = new CertificateValidator();
+			DefaultCertificateValidator = new CertificateValidator(settings.UseOnlineRevocationCheck);
 			DefaultMessageProtection = new SignThenEncryptMessageProtection();
 			ServiceBus = new ServiceBusCore(this);
 

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -32,7 +32,10 @@ namespace Helsenorge.Messaging
 		/// Indicates if we should ignore certificate errors when sending
 		/// </summary>
 		public bool IgnoreCertificateErrorOnSend { get; set; }
-
+        /// <summary>
+        /// Use online certificate revocation list (CRL) check. Default true.
+        /// </summary>
+        public bool UseOnlineRevocationCheck { get; set; } = true;
         /// <summary>
         /// Provides access to service bus settings
         /// </summary>

--- a/src/Helsenorge.Registries/CertificateValidator.cs
+++ b/src/Helsenorge.Registries/CertificateValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Helsenorge.Registries.Abstractions;
@@ -10,6 +11,16 @@ namespace Helsenorge.Registries
 	/// </summary>
 	public class CertificateValidator : ICertificateValidator
 	{
+	    private readonly bool _useOnlineRevocationCheck;
+
+        /// <summary>
+        /// CertificateValidator constructor
+        /// </summary>
+        /// <param name="useOnlineRevocationCheck">Should online certificate revocation list be used. Optional, default true.</param>
+	    public CertificateValidator(bool useOnlineRevocationCheck = true)
+	    {
+	        _useOnlineRevocationCheck = useOnlineRevocationCheck;
+	    }
 		/// <summary>
 		/// Validates the provided certificate
 		/// </summary>
@@ -50,7 +61,7 @@ namespace Helsenorge.Registries
 			{
 				ChainPolicy =
 				{
-					RevocationMode = X509RevocationMode.Online,
+					RevocationMode = _useOnlineRevocationCheck ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
 					RevocationFlag = X509RevocationFlag.EntireChain,
 					UrlRetrievalTimeout = TimeSpan.FromSeconds(30),
 					VerificationTime = DateTime.Now,
@@ -77,6 +88,7 @@ namespace Helsenorge.Registries
 					}
 					sb.AppendLine(status.StatusInformation);
 				}
+                Debug.WriteLine(sb.ToString());
 				return result;
 			}
 		}

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -60,7 +60,7 @@ namespace Helsenorge.Registries
             _adressRegistry = adressRegistry;
 			_invoker = new SoapServiceInvoker(settings.WcfConfiguration);
 			_invoker.SetClientCredentials(_settings.UserName, _settings.Password);
-			CertificateValidator = new CertificateValidator();
+			CertificateValidator = new CertificateValidator(_settings.UseOnlineRevocationCheck);
 		}
 
 		/// <summary>

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistrySettings.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistrySettings.cs
@@ -32,5 +32,9 @@ namespace Helsenorge.Registries
 		/// The HerId that belongs to me. In CPA operations, two communication parties may be returned, need to know which one is us
 		/// </summary>
 		public int MyHerId { get; set; }
+	    /// <summary>
+	    /// Use online certificate revocation list (CRL) check. Default true.
+	    /// </summary>
+	    public bool UseOnlineRevocationCheck { get; set; } = true;
 	}
 }


### PR DESCRIPTION
Adding setting property for turning online CRL check on or off. Added CertificateValidator constructor which uses the CRL check property. Useful when in an environment with no Internet access, where OCSP is not available, causing certificate validation to fail.