### PR TITLE
Fixed mapping of Name from AR

### DIFF
--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -197,7 +197,7 @@ namespace Helsenorge.Registries
         {
             var details = new CommunicationPartyDetails
             {
-                Name = communicationParty.DisplayName,
+                Name = !string.IsNullOrEmpty(communicationParty.DisplayName) ? communicationParty.DisplayName : communicationParty.Name,
                 HerId = communicationParty.HerId,
             };
 


### PR DESCRIPTION
Fixed mapping of Name from AR, if displayname is empty (as it often is) then we use the name instead