### PR TITLE
Fix: CertificateErrors enum conforms to how bit flags should be defined

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/CertificateErrors.cs
+++ b/src/Helsenorge.Registries/Abstractions/CertificateErrors.cs
@@ -32,10 +32,10 @@ namespace Helsenorge.Registries.Abstractions
         /// <summary>
         /// Unable to determine revocation status. Service may be unavailable
         /// </summary>
-        RevokedUnknown = 6,
+        RevokedUnknown = 16,
         /// <summary>
         /// The certificate is missing
         /// </summary>
-        Missing = 7
+        Missing = 32
     }
 }


### PR DESCRIPTION
Issue #27 Enum flags with invalid(?) values  