### PR TITLE
Fix thread sync problems when hosted in ASP.NET

### DIFF
--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.2.0")]
-[assembly: AssemblyFileVersion("2.1.2.0")]
+[assembly: AssemblyVersion("2.1.3.0")]
+[assembly: AssemblyFileVersion("2.1.3.0")]
 
 [assembly: CLSCompliant(false)]
 

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$-beta02</version>
+    <version>$version$-beta03</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$-beta01</version>
+    <version>$version$-beta02</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$-beta03</version>
+    <version>$version$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$version$-beta01</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -247,7 +247,7 @@ namespace Helsenorge.Messaging.ServiceBus
             
             var clonedMessage = originalMessage.Clone();
             // update some properties on the cloned message
-            clonedMessage.To = await ConstructQueueName(logger, originalMessage.FromHerId, QueueType.Error); // change target 
+            clonedMessage.To = await ConstructQueueName(logger, originalMessage.FromHerId, QueueType.Error).ConfigureAwait(false); // change target 
             clonedMessage.TimeToLive = Settings.Error.TimeToLive;
             clonedMessage.FromHerId = originalMessage.ToHerId;
             clonedMessage.ToHerId = originalMessage.FromHerId;

--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -74,7 +74,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                await CacheExtensions.WriteValueToCache(logger, _cache, key, party, _settings.CachingInterval).ConfigureAwait(false);
+                CacheExtensions.WriteValueToCache(logger, _cache, key, party, _settings.CachingInterval);
             }
             return party == null ? default(CommunicationPartyDetails) : MapCommunicationPartyDetails(party);
         }
@@ -116,7 +116,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval).ConfigureAwait(false);
+                CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval);
             }
             return certificateDetails == null ? default(Abstractions.CertificateDetails) : MapCertificateDetails(herId, certificateDetails);
         }
@@ -158,7 +158,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval).ConfigureAwait(false);
+                CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval);
             }
             return certificateDetails == null ? default(Abstractions.CertificateDetails) : MapCertificateDetails(herId, certificateDetails);
         }

--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -45,7 +45,7 @@ namespace Helsenorge.Registries
         /// <returns>Communication details if found, otherwise null</returns>
         public async Task<CommunicationPartyDetails> FindCommunicationPartyDetailsAsync(ILogger logger, int herId)
         {
-            return await FindCommunicationPartyDetailsAsync(logger, herId, false);
+            return await FindCommunicationPartyDetailsAsync(logger, herId, false).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                CacheExtensions.WriteValueToCache(logger, _cache, key, party, _settings.CachingInterval);
+                await CacheExtensions.WriteValueToCache(logger, _cache, key, party, _settings.CachingInterval).ConfigureAwait(false);
             }
             return party == null ? default(CommunicationPartyDetails) : MapCommunicationPartyDetails(party);
         }
@@ -87,7 +87,7 @@ namespace Helsenorge.Registries
         /// <returns></returns>
         public async Task<Abstractions.CertificateDetails> GetCertificateDetailsForEncryptionAsync(ILogger logger, int herId)
         {
-            return await GetCertificateDetailsForEncryptionAsync(logger, herId, false);
+            return await GetCertificateDetailsForEncryptionAsync(logger, herId, false).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval);
+                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval).ConfigureAwait(false);
             }
             return certificateDetails == null ? default(Abstractions.CertificateDetails) : MapCertificateDetails(herId, certificateDetails);
         }
@@ -129,7 +129,7 @@ namespace Helsenorge.Registries
         /// <returns></returns>
         public async Task<Abstractions.CertificateDetails> GetCertificateDetailsForValidatingSignatureAsync(ILogger logger, int herId)
         {
-            return await GetCertificateDetailsForValidatingSignatureAsync(logger, herId, false);
+            return await GetCertificateDetailsForValidatingSignatureAsync(logger, herId, false).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval);
+                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval).ConfigureAwait(false);
             }
             return certificateDetails == null ? default(Abstractions.CertificateDetails) : MapCertificateDetails(herId, certificateDetails);
         }

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -108,8 +108,8 @@ namespace Helsenorge.Registries
             if (string.IsNullOrEmpty(xmlString))
             {
                 result = CreateDummyCollaborationProtocolProfile(counterpartyHerId,
-                    await _adressRegistry.GetCertificateDetailsForEncryptionAsync(logger, counterpartyHerId),
-                    await _adressRegistry.GetCertificateDetailsForValidatingSignatureAsync(logger, counterpartyHerId));
+                    await _adressRegistry.GetCertificateDetailsForEncryptionAsync(logger, counterpartyHerId).ConfigureAwait(false),
+                    await _adressRegistry.GetCertificateDetailsForValidatingSignatureAsync(logger, counterpartyHerId).ConfigureAwait(false));
             }
             else
             {
@@ -117,7 +117,7 @@ namespace Helsenorge.Registries
                 result = doc.Root == null ? null : MapFrompartyInfo(doc.Root.Element(_ns + "PartyInfo"));
             }
 
-            CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval);
+            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
             return result;
         }
 
@@ -139,7 +139,7 @@ namespace Helsenorge.Registries
         /// <returns></returns>
         public async Task<CollaborationProtocolProfile> FindAgreementByIdAsync(ILogger logger, Guid id)
         {
-            return await FindAgreementByIdAsync(logger, id, false);
+            return await FindAgreementByIdAsync(logger, id, false).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Helsenorge.Registries
             result = MapFrompartyInfo(node);
             result.CpaId = id;
 
-            CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval);
+            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
             return result;
         }
 
@@ -216,7 +216,7 @@ namespace Helsenorge.Registries
         /// <returns></returns>
         public async Task<CollaborationProtocolProfile> FindAgreementForCounterpartyAsync(ILogger logger, int counterpartyHerId)
         {
-            return await FindAgreementForCounterpartyAsync(logger, counterpartyHerId, false);
+            return await FindAgreementForCounterpartyAsync(logger, counterpartyHerId, false).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace Helsenorge.Registries
             {
                 // if there are error getting a proper CPA, we fallback to getting CPP.
                 logger.LogWarning($"Failed to resolve CPA between {_settings.MyHerId} and {counterpartyHerId}. {ex.Message}");
-                return await FindProtocolForCounterpartyAsync(logger, counterpartyHerId);
+                return await FindProtocolForCounterpartyAsync(logger, counterpartyHerId).ConfigureAwait(false);
             }
 
             if (string.IsNullOrEmpty(details?.CollaborationProtocolAgreementXml)) return null;
@@ -268,7 +268,7 @@ namespace Helsenorge.Registries
             result = MapFrompartyInfo(node);
             result.CpaId = Guid.Parse(doc.Root.Attribute(_ns + "cpaid").Value);
             
-            CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval);
+            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
             return result;
         }
         

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -117,7 +117,7 @@ namespace Helsenorge.Registries
                 result = doc.Root == null ? null : MapFrompartyInfo(doc.Root.Element(_ns + "PartyInfo"));
             }
 
-            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
+            CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval);
             return result;
         }
 
@@ -194,7 +194,7 @@ namespace Helsenorge.Registries
             result = MapFrompartyInfo(node);
             result.CpaId = id;
 
-            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
+            CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval);
             return result;
         }
 
@@ -268,7 +268,7 @@ namespace Helsenorge.Registries
             result = MapFrompartyInfo(node);
             result.CpaId = Guid.Parse(doc.Root.Attribute(_ns + "cpaid").Value);
             
-            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
+            CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval);
             return result;
         }
         

--- a/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
+++ b/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
@@ -23,21 +23,23 @@ namespace Helsenorge.Registries.Utilities
             }
         }
 
-        public static async Task WriteValueToCache(ILogger logger, IDistributedCache cache, string key, object value, TimeSpan expires)
+        public static void WriteValueToCache(ILogger logger, IDistributedCache cache, string key, object value, TimeSpan expires)
         {
             if (expires == TimeSpan.Zero) return;
             if (value == null) return;
 
             var options = new DistributedCacheEntryOptions();
             options.SetAbsoluteExpiration(expires);
-            try
+
+            logger.LogDebug("WriteValueToCache key {0}", key);
+
+            var task = cache.SetAsync(key, ObjectToByteArray(value), options);
+            if (task.Exception != null)
             {
-                await cache.SetAsync(key, ObjectToByteArray(value), options).ConfigureAwait(false);
+                logger.LogWarning(1, task.Exception, $"Failed writing value {key} from cache");
             }
-            catch (Exception ex)
-            {	
-                logger.LogWarning(1, ex, $"Failed writing value {key} to cache");
-            }
+            
+            logger.LogDebug("WriteValueToCache key {0} complete", key);
         }
 
 

--- a/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
+++ b/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
@@ -33,13 +33,14 @@ namespace Helsenorge.Registries.Utilities
 
             logger.LogDebug("WriteValueToCache key {0}", key);
 
-            var task = cache.SetAsync(key, ObjectToByteArray(value), options);
-            if (task.Exception != null)
-            {
-                logger.LogWarning(1, task.Exception, $"Failed writing value {key} from cache");
-            }
-            
-            logger.LogDebug("WriteValueToCache key {0} complete", key);
+            cache.SetAsync(key, ObjectToByteArray(value), options)
+                .ContinueWith(
+                    t => { logger.LogDebug("WriteValueToCache key {0} complete", key);
+                    if (t.Exception != null)
+                    {
+                        logger.LogWarning(1, t.Exception, $"Failed writing value {key} to cache.");
+                    }
+                });
         }
 
 

--- a/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
+++ b/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
@@ -33,16 +33,16 @@ namespace Helsenorge.Registries.Utilities
 
             logger.LogDebug("WriteValueToCache key {0}", key);
 
-            cache.SetAsync(key, ObjectToByteArray(value), options)
-                .ContinueWith(
-                    t => { logger.LogDebug("WriteValueToCache key {0} complete", key);
-                    if (t.Exception != null)
-                    {
-                        logger.LogWarning(1, t.Exception, $"Failed writing value {key} to cache.");
-                    }
-                });
+            try
+            {
+                cache.Set(key, ObjectToByteArray(value), options);
+                logger.LogDebug("WriteValueToCache key {0} complete", key);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(1, ex, $"Failed writing value {key} to cache.");
+            }
         }
-
 
         private static byte[] ObjectToByteArray(object value)
         {

--- a/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
+++ b/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
@@ -23,7 +23,7 @@ namespace Helsenorge.Registries.Utilities
             }
         }
 
-        public static void WriteValueToCache(ILogger logger, IDistributedCache cache, string key, object value, TimeSpan expires)
+        public static async Task WriteValueToCache(ILogger logger, IDistributedCache cache, string key, object value, TimeSpan expires)
         {
             if (expires == TimeSpan.Zero) return;
             if (value == null) return;
@@ -35,7 +35,7 @@ namespace Helsenorge.Registries.Utilities
 
             try
             {
-                cache.Set(key, ObjectToByteArray(value), options);
+                await cache.SetAsync(key, ObjectToByteArray(value), options).ConfigureAwait(false);
                 logger.LogDebug("WriteValueToCache key {0} complete", key);
             }
             catch (Exception ex)


### PR DESCRIPTION
Change call to SetAsync on IDistributedCache to be fire and forget because of thread locking errors and to improve performance of framework