### PR TITLE
Handle invalid replyto queue with logging and moving message to DLQ

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
@@ -106,5 +106,9 @@ namespace Helsenorge.Messaging.Abstractions
         /// Renews the peerlock of the message
         /// </summary>
         void RenewLock();
+        /// <summary>
+        /// Sends this message to the deadletter queue
+        /// </summary>
+        void DeadLetter();
     }
 }

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$version$-beta04</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/src/Helsenorge.Messaging/Http/IncomingHttpMessage.cs
+++ b/src/Helsenorge.Messaging/Http/IncomingHttpMessage.cs
@@ -147,6 +147,11 @@ namespace Helsenorge.Messaging.Http
             return Task.CompletedTask;
         }
 
+        public void DeadLetter()
+        {
+            throw new NotImplementedException();
+        }
+
         public IMessagingMessage Clone()
         {
             return new IncomingHttpMessage { AMQPMessage = AMQPMessage };

--- a/src/Helsenorge.Messaging/Http/OutgoingHttpMessage.cs
+++ b/src/Helsenorge.Messaging/Http/OutgoingHttpMessage.cs
@@ -78,6 +78,11 @@ namespace Helsenorge.Messaging.Http
             throw new NotImplementedException();
         }
 
+        public void DeadLetter()
+        {
+            throw new NotImplementedException();
+        }
+
         public IMessagingMessage Clone()
         {
             throw new NotImplementedException();

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -204,6 +204,12 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                 Core.ReportErrorToExternalSender(Logger, EventIds.DataMismatch, message, "abuse:spoofing-attack", ex.Message, null, ex);
                 MessagingNotification.NotifyHandledException(message, ex);
             }
+            catch (AggregateException ex) when (ex.InnerException is MessagingException && ((MessagingException)ex.InnerException).EventId.Id == EventIds.Send.Id) 
+            {
+                //message should go to dlc right away, we get an error sending the reply
+                message.DeadLetter();
+                MessagingNotification.NotifyHandledException(message, ex);
+            }
             catch (Exception ex) // unknown error
             {
                 message.AddDetailsToException(ex);

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -208,6 +208,8 @@ namespace Helsenorge.Messaging.ServiceBus
             }
             catch (Exception ex)
             {
+                logger.LogException("Cannot send message to service bus. Invalid endpoint.", ex);
+
                 throw new MessagingException(ex.Message)
                 {
                     EventId = EventIds.Send

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -90,6 +90,8 @@ namespace Helsenorge.Messaging.ServiceBus
         [DebuggerStepThrough]
         public void Complete() => _implementation.Complete();
         [DebuggerStepThrough]
+        public void DeadLetter() => _implementation.DeadLetter();
+        [DebuggerStepThrough]
         public Task CompleteAsync() => _implementation.CompleteAsync();
         [DebuggerStepThrough]
         public void Dispose() => _implementation.Dispose();

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockFactory.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockFactory.cs
@@ -17,7 +17,8 @@ namespace Helsenorge.Messaging.Tests.Mocks
         public MockCommunicationParty OtherPartyWithOnlyCpp { get; }
 
         public Dictionary<string, List<IMessagingMessage>> Qeueues { get; } = new Dictionary<string, List<IMessagingMessage>>();
-        
+        public List<IMessagingMessage> DeadLetterQueue { get; } = new List<IMessagingMessage>();
+
         public bool IsClosed => false;
 
         public MockFactory(int otherHerID)
@@ -56,7 +57,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
             Synchronous = new MockQueue($"{herId}_sync");
             Error = new MockQueue($"{herId}_error");
             SynchronousReply = new MockQueue($"{herId}_syncreply");
-
+            
             factory.Qeueues.Add(Asynchronous.Name, Asynchronous.Messages);
             factory.Qeueues.Add(Synchronous.Name, Synchronous.Messages);
             factory.Qeueues.Add(Error.Name, Error.Messages);

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
@@ -55,8 +55,15 @@ namespace Helsenorge.Messaging.Tests.Mocks
             Queue.Remove(this);
             return Task.CompletedTask;
         }
+        public void DeadLetter()
+        {
+            Queue.Remove(this);
+            DeadLetterQueue.Add(this);
+        }
 
         public List<IMessagingMessage> Queue { get; set; }
+
+        public List<IMessagingMessage> DeadLetterQueue { get; set; }
 
         public IMessagingMessage Clone()
         {
@@ -69,6 +76,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
                 ReplyTo = ReplyTo,
                 CorrelationId = CorrelationId,
                 Queue = Queue,
+                DeadLetterQueue = DeadLetterQueue,
                 ApplicationTimestamp = ApplicationTimestamp,
                 CpaId = CpaId,
                 FromHerId = FromHerId,

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockSender.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockSender.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Helsenorge.Messaging.Abstractions;
+using System;
 
 namespace Helsenorge.Messaging.Tests.Mocks
 {
@@ -8,7 +9,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
     {
         private readonly MockFactory _factory;
         private readonly string _id;
-
+        
         public MockSender(MockFactory factory, string id)
         {
             _factory = factory;
@@ -33,6 +34,12 @@ namespace Helsenorge.Messaging.Tests.Mocks
             
             var m = message as MockMessage;
             m.Queue = queue;
+            
+            //validate To queue so we can test errors connecting to queues. Different implementations throw different exceptions
+            if (!string.IsNullOrEmpty(message.To) && message.To.StartsWith("Dialog_"))
+            {
+                throw new MessagingException();
+            }
 
             queue.Add(message);
             return Task.CompletedTask;


### PR DESCRIPTION
Sync messages can have an invalid reply to queue that is currently results in an unhandled exception. These should be handled by sending the message to Dead Letter Queue (sync messages cannot be reprocessed after 1 minute)