### PR TITLE
Remove default values for ScheduledSendTimeUtc

### DIFF
--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.3.0")]
-[assembly: AssemblyFileVersion("2.1.3.0")]
+[assembly: AssemblyVersion("2.1.4.0")]
+[assembly: AssemblyFileVersion("2.1.4.0")]
 
 [assembly: CLSCompliant(false)]
 

--- a/src/Helsenorge.Messaging.Client/Program.cs
+++ b/src/Helsenorge.Messaging.Client/Program.cs
@@ -137,7 +137,6 @@ namespace Helsenorge.Messaging.Client
                                 MessageFunction = _clientSettings.MessageFunction,
                                 ToHerId = _clientSettings.ToHerId,
                                 MessageId = Guid.NewGuid().ToString("D"),
-                                ScheduledSendTimeUtc = DateTime.UtcNow,
                                 PersonalId = "99999999999",
                                 Payload = XDocument.Load(File.OpenRead(s))
                             }));
@@ -185,7 +184,6 @@ namespace Helsenorge.Messaging.Client
                         MessageFunction = _clientSettings.MessageFunction,
                         ToHerId = _clientSettings.ToHerId,
                         MessageId = Guid.NewGuid().ToString("D"),
-                        ScheduledSendTimeUtc = DateTime.UtcNow,
                         PersonalId = "99999999999",
                         Payload = XDocument.Load(File.OpenRead(s))
 

--- a/src/Helsenorge.Messaging/Abstractions/OutgoingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/OutgoingMessage.cs
@@ -42,7 +42,6 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         public OutgoingMessage()
         {
-            ScheduledSendTimeUtc = DateTime.UtcNow;
         }
     }
 }

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$-beta01</version>
+    <version>$version$-beta02</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$version$-beta01</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>


### PR DESCRIPTION
* OutgoingMessage.ScheduledSendTimeUtc is mapped to
  BrokeredMessage.ScheduleEnqueTimeUtc and should only be set when we need
  delayed messaging. See http://bit.ly/2o8nSof