### PR TITLE
Send message with decryption error to error queue

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
@@ -106,5 +106,9 @@ namespace Helsenorge.Messaging.Abstractions
         /// Renews the peerlock of the message
         /// </summary>
         void RenewLock();
+        /// <summary>
+        /// Sends this message to the deadletter queue
+        /// </summary>
+        void DeadLetter();
     }
 }

--- a/src/Helsenorge.Messaging/Http/IncomingHttpMessage.cs
+++ b/src/Helsenorge.Messaging/Http/IncomingHttpMessage.cs
@@ -147,6 +147,11 @@ namespace Helsenorge.Messaging.Http
             return Task.CompletedTask;
         }
 
+        public void DeadLetter()
+        {
+            throw new NotImplementedException();
+        }
+
         public IMessagingMessage Clone(bool includePayload = true)
         {
             return new IncomingHttpMessage { AMQPMessage = AMQPMessage };

--- a/src/Helsenorge.Messaging/Http/OutgoingHttpMessage.cs
+++ b/src/Helsenorge.Messaging/Http/OutgoingHttpMessage.cs
@@ -78,6 +78,11 @@ namespace Helsenorge.Messaging.Http
             throw new NotImplementedException();
         }
 
+        public void DeadLetter()
+        {
+            throw new NotImplementedException();
+        }
+
         public IMessagingMessage Clone(bool includePayload = true)
         {
             throw new NotImplementedException();

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -204,6 +204,12 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                 Core.ReportErrorToExternalSender(Logger, EventIds.DataMismatch, message, "abuse:spoofing-attack", ex.Message, null, ex);
                 MessagingNotification.NotifyHandledException(message, ex);
             }
+            catch (AggregateException ex) when (ex.InnerException is MessagingException && ((MessagingException)ex.InnerException).EventId.Id == EventIds.Send.Id) 
+            {
+                //message should go to dlc right away, we get an error sending the reply
+                message.DeadLetter();
+                MessagingNotification.NotifyHandledException(message, ex);
+            }
             catch (Exception ex) // unknown error
             {
                 message.AddDetailsToException(ex);

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -206,8 +206,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
             }
             catch (AggregateException ex) when (ex.InnerException is MessagingException && ((MessagingException)ex.InnerException).EventId.Id == EventIds.Send.Id) 
             {
-                //message should go to dlc right away, we get an error sending the reply
-                message.DeadLetter();
+                Core.ReportErrorToExternalSender(Logger, EventIds.ApplicationReported, message, "transport:invalid-field-value", ex.Message, null, ex);
                 MessagingNotification.NotifyHandledException(message, ex);
             }
             catch (Exception ex) // unknown error

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -208,6 +208,8 @@ namespace Helsenorge.Messaging.ServiceBus
             }
             catch (Exception ex)
             {
+                logger.LogException("Cannot send message to service bus. Invalid endpoint.", ex);
+
                 throw new MessagingException(ex.Message)
                 {
                     EventId = EventIds.Send

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockFactory.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockFactory.cs
@@ -17,7 +17,8 @@ namespace Helsenorge.Messaging.Tests.Mocks
         public MockCommunicationParty OtherPartyWithOnlyCpp { get; }
 
         public Dictionary<string, List<IMessagingMessage>> Qeueues { get; } = new Dictionary<string, List<IMessagingMessage>>();
-        
+        public List<IMessagingMessage> DeadLetterQueue { get; } = new List<IMessagingMessage>();
+
         public bool IsClosed => false;
 
         public MockFactory(int otherHerID)
@@ -56,7 +57,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
             Synchronous = new MockQueue($"{herId}_sync");
             Error = new MockQueue($"{herId}_error");
             SynchronousReply = new MockQueue($"{herId}_syncreply");
-
+            
             factory.Qeueues.Add(Asynchronous.Name, Asynchronous.Messages);
             factory.Qeueues.Add(Synchronous.Name, Synchronous.Messages);
             factory.Qeueues.Add(Error.Name, Error.Messages);

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
@@ -55,8 +55,15 @@ namespace Helsenorge.Messaging.Tests.Mocks
             Queue.Remove(this);
             return Task.CompletedTask;
         }
+        public void DeadLetter()
+        {
+            Queue.Remove(this);
+            DeadLetterQueue.Add(this);
+        }
 
         public List<IMessagingMessage> Queue { get; set; }
+
+        public List<IMessagingMessage> DeadLetterQueue { get; set; }
 
         public IMessagingMessage Clone(bool includePayload = true)
         {
@@ -70,6 +77,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
                 ReplyTo = ReplyTo,
                 CorrelationId = CorrelationId,
                 Queue = Queue,
+                DeadLetterQueue = DeadLetterQueue,
                 ApplicationTimestamp = ApplicationTimestamp,
                 CpaId = CpaId,
                 FromHerId = FromHerId,

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockSender.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockSender.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Helsenorge.Messaging.Abstractions;
+using System;
 
 namespace Helsenorge.Messaging.Tests.Mocks
 {
@@ -8,7 +9,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
     {
         private readonly MockFactory _factory;
         private readonly string _id;
-
+        
         public MockSender(MockFactory factory, string id)
         {
             _factory = factory;
@@ -33,6 +34,12 @@ namespace Helsenorge.Messaging.Tests.Mocks
             
             var m = message as MockMessage;
             m.Queue = queue;
+            
+            //validate To queue so we can test errors connecting to queues. Different implementations throw different exceptions
+            if (!string.IsNullOrEmpty(message.To) && message.To.StartsWith("Dialog_"))
+            {
+                throw new MessagingException();
+            }
 
             queue.Add(message);
             return Task.CompletedTask;

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/SynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/SynchronousReceiveTests.cs
@@ -49,17 +49,16 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         }
 
         [TestMethod]
-        public void Synchronous_Receive_InvalidReplyToQueue_SendToDeadLetterQueue()
+        public void Synchronous_Receive_InvalidReplyToQueue_SendToErrorQueue()
         {
             RunReceive(
                 postValidation: () =>
                 {
                     Assert.IsTrue(_startingCalled);
-                    Assert.IsTrue(_receivedCalled);
                     Assert.IsTrue(_handledExceptionCalled);
                     Assert.AreEqual(0, MockFactory.Helsenorge.Synchronous.Messages.Count);
-                    Assert.AreEqual(1, MockFactory.DeadLetterQueue.Count);
-                    Assert.AreEqual(0, MockFactory.OtherParty.SynchronousReply.Messages.Count);
+                    Assert.AreEqual(1, MockFactory.OtherParty.Error.Messages.Count);
+                    Assert.AreEqual("transport:invalid-field-value", MockFactory.OtherParty.Error.Messages.First().Properties["errorCondition"]);
                     var logEntry = MockLoggerProvider.Entries.Where(l => l.LogLevel == LogLevel.Critical);
                     Assert.AreEqual(1, logEntry.Count());
                     Assert.IsTrue(logEntry.First().Message == "Cannot send message to service bus. Invalid endpoint.");
@@ -70,6 +69,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
                 },
                 messageModification: (m) => { m.ReplyTo = "Dialog_" + m.ReplyTo; });
         }
+
 
         [TestMethod]
         public void Synchronous_ReceiveHerIdMismatch_ErrorQueueWithSpoofingErrorCode()


### PR DESCRIPTION
There was no handling of XDocument parse errors in unprotecting a received message so these messages were re-tried and eventually sent to DLQ.

These messages will not succeed on subsequent attempts so in this change:

    A specific error is thrown (PayloadDecryptionException)
    The error is caught as a known exception, the message is sent to the senders error queue and logged

Also added support for sending a message to the deadletter queue immediately. This is currently unused.