### PR TITLE
Improve error message for invalid remote encryption certificate

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -125,11 +125,11 @@ namespace Helsenorge.Messaging.ServiceBus
             {
                 if (Core.Settings.IgnoreCertificateErrorOnSend)
                 {
-                    logger.LogError(EventIds.RemoteCertificate, "Remote encryption certificate is not valid");
+                    logger.LogError(EventIds.RemoteCertificate, $"Remote encryption certificate {encryption?.SerialNumber} for {outgoingMessage.ToHerId.ToString()} is not valid");
                 }
                 else
                 {
-                    throw new MessagingException("Remote encryption certificate is not valid")
+                    throw new MessagingException($"Remote encryption certificate {encryption?.SerialNumber} for {outgoingMessage.ToHerId.ToString()} is not valid")
                     {
                         EventId = EventIds.RemoteCertificate
                     };


### PR DESCRIPTION
Remote encryption certificate error currently provides no information about which certificate has caused the fault. Include the serial number of the certificate and HerId to help troubleshooting.