### PR TITLE
Legg til NotifyErrorMessageReceivedStarting method

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/IMessagingNotification.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingNotification.cs
@@ -33,6 +33,11 @@ namespace Helsenorge.Messaging.Abstractions
         /// <param name="message"></param>
         void NotifyErrorMessageReceived(IMessagingMessage message);
         /// <summary>
+        /// Called to notify that we are starting to process an error message
+        /// </summary>
+        /// <param name="message">Information about the message</param>
+        void NotifyErrorMessageReceivedStarting(IncomingMessage message);
+        /// <summary>
         /// Called to notify that a synchronous message is ready for processing
         /// </summary>
         /// <param name="message">Information about the message</param>

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Messaging.xml</DocumentationFile>
     <Product>Helsenorge Messaging</Product>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Abstractions\IMessageReceiverFactory.cs" />

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Messaging.xml</DocumentationFile>
     <Product>Helsenorge Messaging</Product>
-    <Version>3.0.2</Version>
+    <Version>3.0.2-beta01</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Abstractions\IMessageReceiverFactory.cs" />

--- a/src/Helsenorge.Messaging/MessagingServer.cs
+++ b/src/Helsenorge.Messaging/MessagingServer.cs
@@ -32,6 +32,8 @@ namespace Helsenorge.Messaging
         private Action<IncomingMessage> _onSynchronousMessageReceivedStarting;
 
         private Action<IMessagingMessage> _onErrorMessageReceived;
+        private Action<IncomingMessage> _onErrorMessageReceivedStarting;
+
         private Action<IMessagingMessage, Exception> _onUnhandledException;
         private Action<IMessagingMessage, Exception> _onHandledException;
 
@@ -136,6 +138,18 @@ namespace Helsenorge.Messaging
         /// </summary>
         /// <param name="action">The delegate that should be called</param>
         public void RegisterErrorMessageReceivedCallback(Action<IMessagingMessage> action) => _onErrorMessageReceived = action;
+
+        /// <summary>
+        /// Registers a delegate that should be called as we start processing a message
+        /// </summary>
+        /// <param name="action">The delegate that should be called</param>
+        public void RegisterErrorMessageReceivedStartingCallback(Action<IncomingMessage> action) => _onErrorMessageReceivedStarting = action;
+
+        void IMessagingNotification.NotifyErrorMessageReceivedStarting(IncomingMessage message)
+        {
+            _logger.LogDebug("NotifyErrorMessageReceivedStarting");
+            _onErrorMessageReceivedStarting?.Invoke(message);
+        }
 
         void IMessagingNotification.NotifyErrorMessageReceived(IMessagingMessage message)
         {

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/ErrorMessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/ErrorMessageListener.cs
@@ -41,7 +41,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
         /// <param name="message">Reference to the incoming message. Some fields may not have values since they get populated later in the processing pipeline.</param>
         protected override void NotifyMessageProcessingStarted(IncomingMessage message)
         {
-            // not relevant for error messages
+            MessagingNotification.NotifyErrorMessageReceivedStarting(message);
         }
         /// <summary>
         /// Called to process message

--- a/src/Helsenorge.Messaging/ServiceBus/Senders/SynchronousSender.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Senders/SynchronousSender.cs
@@ -199,6 +199,11 @@ namespace Helsenorge.Messaging.ServiceBus.Senders
 
         }
 
+        public void NotifyErrorMessageReceivedStarting(IncomingMessage message)
+        {
+
+        }
+
         public XDocument NotifySynchronousMessageReceived(IncomingMessage message)
         {
             OnSynchronousReplyMessageReceived?.Invoke(message);

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Registries.xml</DocumentationFile>
-    <Version>3.0.2</Version>    
+    <Version>3.0.2-beta01</Version>    
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Registries.xml</DocumentationFile>
-    <Version>3.0.1</Version>    
+    <Version>3.0.2</Version>    
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/ErrorReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/ErrorReceiveTests.cs
@@ -10,12 +10,14 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
     public class ErrorReceiveTests : BaseTest
     {
         private bool _errorReceiveCalled;
+        private bool _errorStartingCalled;
 
         [TestInitialize]
         public override void Setup()
         {
             base.Setup();
             _errorReceiveCalled = false;
+            _errorStartingCalled = false;
         }
 
         [TestMethod]
@@ -29,6 +31,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
                 {
                     Assert.IsTrue(_errorReceiveCalled);
                     Assert.AreEqual(0, MockFactory.Helsenorge.Error.Messages.Count);
+                    Assert.IsTrue(_errorStartingCalled, "Error message received starting callback not called");
                     //Assert.IsNotNull(Logger.FindEntry(EventIds.ExternalReportedError)); //TODO: find out why this crashes. Works when running with debugger. Timing issue?
                 },
                 wait: () => _errorReceiveCalled,
@@ -49,6 +52,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
                 {
                     Assert.IsTrue(_errorReceiveCalled);
                     Assert.AreEqual(0, MockFactory.Helsenorge.Error.Messages.Count);
+                    Assert.IsTrue(_errorStartingCalled, "Error message received starting callback not called");
                     //Assert.IsNotNull(Logger.FindEntry(EventIds.ExternalReportedError)); //TODO: find out why this crashes. Works when running with debugger. Timing issue?
                 },
                 wait: () => _errorReceiveCalled,
@@ -71,6 +75,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
             MockFactory.Helsenorge.Error.Messages.Add(message);
 
             Server.RegisterErrorMessageReceivedCallback((m) => { _errorReceiveCalled = true; });
+            Server.RegisterErrorMessageReceivedStartingCallback((m) => _errorStartingCalled = true);
             Server.Start();
 
             Wait(15, wait); // we have a high timeout in case we do a bit of debugging. With more extensive debugging (breakpoints), we will get a timeout


### PR DESCRIPTION
There is no NotifyErrorMessageReceivedStarting method called during message processing. This has resulted in difficulties for clients setting a correlation for a request and so made managing the error queue problematic.