### PR TITLE
Default SynchronousSettings.ProcessingTasks to 2

### DIFF
--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -140,7 +140,7 @@ namespace Helsenorge.Messaging
         /// <summary>
         /// Number of processing tasks
         /// </summary>
-        public int ProcessingTasks { get; set; }
+        public int ProcessingTasks { get; set; } = 2;
         /// <summary>
         /// Time to live for messages sent
         /// </summary>


### PR DESCRIPTION
* Revert setting of SynchronousSettings.ProcessingTasks to zero in
  3904c373
* Parties that want to override the default would have to set this to
  zero manually