### PR TITLE
Removed CPA lookup when retriving error messages

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -249,6 +249,8 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
         {
             Guid id;
 
+            // if we receive an error message then CPA isn't needed because we're not decrypting the message and then the CPA info isn't needed
+            if (QueueType == QueueType.Error) return null;
             if (Guid.TryParse(message.CpaId, out id) && (id != Guid.Empty))
             {
                 return await Core.CollaborationProtocolRegistry.FindAgreementByIdAsync(Logger, id).ConfigureAwait(false);

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/ErrorReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/ErrorReceiveTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Xml.Linq;
+using System.Linq;
 using Helsenorge.Messaging.Abstractions;
 using Helsenorge.Messaging.Tests.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -32,7 +33,8 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
                     Assert.IsTrue(_errorReceiveCalled);
                     Assert.AreEqual(0, MockFactory.Helsenorge.Error.Messages.Count);
                     Assert.IsTrue(_errorStartingCalled, "Error message received starting callback not called");
-                    //Assert.IsNotNull(Logger.FindEntry(EventIds.ExternalReportedError)); //TODO: find out why this crashes. Works when running with debugger. Timing issue?
+                    Assert.IsNull(MockLoggerProvider.Entries.FirstOrDefault(e => e.Message.Contains("CPA_FindAgreementForCounterpartyAsync_0_93252")));
+                    Assert.IsNotNull(MockLoggerProvider.FindEntry(EventIds.ExternalReportedError));
                 },
                 wait: () => _errorReceiveCalled,
                 messageModification: (m) =>
@@ -53,7 +55,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
                     Assert.IsTrue(_errorReceiveCalled);
                     Assert.AreEqual(0, MockFactory.Helsenorge.Error.Messages.Count);
                     Assert.IsTrue(_errorStartingCalled, "Error message received starting callback not called");
-                    //Assert.IsNotNull(Logger.FindEntry(EventIds.ExternalReportedError)); //TODO: find out why this crashes. Works when running with debugger. Timing issue?
+                    Assert.IsNotNull(MockLoggerProvider.FindEntry(EventIds.ExternalReportedError));
                 },
                 wait: () => _errorReceiveCalled,
                 messageModification: (m) =>


### PR DESCRIPTION
Error messages will not be decrypted, so CPA information isn't needed.
CPA information is only needed for the decryption.