### PR TITLE
Add ProcessSpecification to CollaborationProtocolRole

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolRole.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolRole.cs
@@ -7,7 +7,8 @@ using System.Threading.Tasks;
 namespace Helsenorge.Registries.Abstractions
 {
     /// <summary>
-    /// A role can be thought of as the party providing a specific service, or in practial terms a message type. 
+    /// A role can be thought of as the party providing a specific service. The CollaborationRole links the role to the ProcessSpecification and messages allowed 
+    /// These are defined in 2 formats; the first example is an older format and the second a newer format that better defines the messages and roles
     /// </summary>
     /// <example>
     /// <![CDATA[
@@ -24,6 +25,27 @@ namespace Helsenorge.Registries.Abstractions
     ///		<tns:CanReceive />
     ///  </tns:ServiceBinding>
     ///	</tns:CollaborationRole>
+    ///	
+    /// <tns:CollaborationRole>
+    ///  <tns:ProcessSpecification tns:name="Dialog_Innbygger_BehandlerOversikt" tns:version="1.0" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes/Dialog_Innbygger_behandlerOversikt.xml" tns:uuid="b86b0d41-21fd-4ab7-86f3-af633ea7b27a" />
+    ///  <tns:Role tns:name="Innbygger" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes#Innbygger" />
+    ///  <tns:ApplicationCertificateRef tns:certId="enc" />
+    ///  <tns:ServiceBinding>
+    ///    <tns:Service tns:type="string">BehandlerOversikt</tns:Service>
+    ///    <tns:CanSend>
+    ///      <tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Behandler_Hent" tns:action="Hent" tns:packageId="package_eKontakt_v1p2" xlink:type="simple">
+    ///        <tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
+    ///        <tns:ChannelId>AMQPSync_30e2b6bb-277d-4507-abb5-e6685f6179bc</tns:ChannelId>
+    ///      </tns:ThisPartyActionBinding>
+    ///    </tns:CanSend>
+    ///    <tns:CanReceive>
+    ///      <tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Svar" tns:action="Svar" tns:packageId="package_dia_v1.1_hp_v1p0" xlink:type="simple">
+    ///        <tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
+    ///        <tns:ChannelId>AMQPSync_30e2b6bb-277d-4507-abb5-e6685f6179bc</tns:ChannelId>
+    ///      </tns:ThisPartyActionBinding>
+    ///    </tns:CanReceive>
+    ///  </tns:ServiceBinding>
+    ///</tns:CollaborationRole>
     /// ]]>
     /// </example>
     [Serializable]
@@ -33,14 +55,21 @@ namespace Helsenorge.Registries.Abstractions
         /// <summary>
         /// Name of role
         /// </summary>
+        [Obsolete("Contains Role.Name for backwards compatibility. Change to use ProcessSpecification.Name or RoleName.")]
         public string Name { get; set; }
+        /// <summary>
+        /// Name of role
+        /// </summary>
+        public string RoleName { get; set; }
         /// <summary>
         /// String representation of version
         /// </summary>
+        [Obsolete("Contains ProcessSpecification.VersionString for backwards compatibility. Change to use ProcessSpecification.VersionString. ")]
         public string VersionString { get; set; }
         /// <summary>
         /// Version of role
         /// </summary>
+        [Obsolete("Contains ProcessSpecification.Version for backwards compatibility. Change to use ProcessSpecification.Version. ")]
         public Version Version
         {
             get
@@ -62,5 +91,9 @@ namespace Helsenorge.Registries.Abstractions
         /// </summary>
         public IList<CollaborationProtocolMessage> ReceiveMessages { get; set; }
 
+        /// <summary>
+        /// Contains information on the name and version of message
+        /// </summary>
+        public ProcessSpecification ProcessSpecification { get; set; }
     }
 }

--- a/src/Helsenorge.Registries/Abstractions/ProcessSpecification.cs
+++ b/src/Helsenorge.Registries/Abstractions/ProcessSpecification.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Helsenorge.Registries.Abstractions
+{
+    /// <summary>
+    /// A ProcessSpecification can be thought of in practial terms as a message type. 
+    /// </summary>
+    /// <example>
+    /// <![CDATA[
+    ///  <tns:ProcessSpecification tns:name="Dialog_Innbygger_Timereservasjon" tns:version="1.1" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes/Dialog_Innbygger_Timereservasjon.xml" tns:uuid="4ab55eaa-a095-4a4f-96e4-48fbf577fe48" />
+    /// ]]>
+    /// </example>
+    [Serializable]
+    public class ProcessSpecification
+    {
+        Version _version;
+        /// <summary>
+        /// Name of process specification
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// String representation of version
+        /// </summary>
+        public string VersionString { get; set; }
+        /// <summary>
+        /// Version of role
+        /// </summary>
+        public Version Version
+        {
+            get
+            {
+                if (_version == null)
+                {
+                    _version = new Version(this.VersionString);
+                }
+                return _version;
+            }
+        }
+    }
+}

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -353,13 +353,21 @@ namespace Helsenorge.Registries
              //	</tns:ServiceBinding>
              //</tns:CollaborationRole>
 
-             var role = new CollaborationProtocolRole
+            var role = new CollaborationProtocolRole
             {
                 ReceiveMessages = new List<CollaborationProtocolMessage>(),
                 SendMessages = new List<CollaborationProtocolMessage>(),
                 Name = element.Element(_ns + "Role")?.Attribute(_ns + "name").Value,
+                VersionString = element.Element(_ns + "ProcessSpecification")?.Attribute(_ns + "version").Value,
+                RoleName = element.Element(_ns + "Role")?.Attribute(_ns + "name").Value
+             };
+
+            var processSpecification = new ProcessSpecification
+            {
+                Name = element.Element(_ns + "ProcessSpecification")?.Attribute(_ns + "name").Value,
                 VersionString = element.Element(_ns + "ProcessSpecification")?.Attribute(_ns + "version").Value
             };
+            role.ProcessSpecification = processSpecification;
 
             var serviceBinding = element.Element(_ns + "ServiceBinding");
             if (serviceBinding == null) return role;

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -102,8 +102,14 @@ namespace Helsenorge.Registries.Tests
 
             var role = profile.Roles[0];
             Assert.AreEqual("DIALOG_INNBYGGER_DIGITALBRUKERreceiver", role.Name);
+            Assert.AreEqual("DIALOG_INNBYGGER_DIGITALBRUKERreceiver", role.RoleName);
             Assert.AreEqual("1.1", role.VersionString);
             Assert.AreEqual(new Version(1, 1), role.Version);
+            Assert.AreEqual("1.1", role.ProcessSpecification.VersionString);
+            Assert.AreEqual(new Version(1, 1), role.ProcessSpecification.Version);
+            Assert.AreEqual("Dialog_Innbygger_Digitalbruker", role.ProcessSpecification.Name);
+
+
             Assert.AreEqual(2, role.ReceiveMessages.Count);
             Assert.AreEqual(2, role.SendMessages.Count);
             var message = role.ReceiveMessages[0];


### PR DESCRIPTION
When mapping Collaboration Protocols from XML, the Name attribute of ProcessSpecification was not included whereas the version was. With recent improvements in the setup of Collaboration Protocols in the Address Register, this has meant an important field is missing. To highlight the changes, the 3 old fields Name, Version and VersionString are marked as obsolete. A new object is available for the ProcessSpecification and a new property is available for the Name attribute of the Role, RoleName