### PR TITLE
Update Registry methods for new CPP format

### DIFF
--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Messaging.xml</DocumentationFile>
     <Product>Helsenorge Messaging</Product>
-    <Version>3.0.4-beta05</Version>
+    <Version>3.0.4-beta06</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Abstractions\IMessageReceiverFactory.cs" />

--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
@@ -97,6 +97,7 @@ namespace Helsenorge.Registries.Abstractions
         }
         /// <summary>
         /// Finds the collaboration information for a specific message
+        /// Find using the ProcessSpecification name as this matches the message name in both new and old Cpp formats
         /// </summary>
         /// <param name="messageName">i.e. DIALOG_INNBYGER_EKONTAKT, DIALOG_INNBYGGER_KOORDINATOR, etc.</param>
         /// <returns></returns>
@@ -104,10 +105,11 @@ namespace Helsenorge.Registries.Abstractions
         {
             if (string.IsNullOrEmpty(messageName)) throw new ArgumentNullException(nameof(messageName));
 
-            return Roles.SelectMany(role => role.SendMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.Ordinal));
+            return Roles.FirstOrDefault(role => role.ProcessSpecification.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase)).SendMessages.FirstOrDefault();
         }
         /// <summary>
         /// Finds the collaboration information for a specific message
+        /// Find using the ProcessSpecification name as this matches the message name in both new and old Cpp formats
         /// </summary>
         /// <param name="messageName">i.e. DIALOG_INNBYGER_EKONTAKT, DIALOG_INNBYGGER_KOORDINATOR, etc.</param>
         /// <returns></returns>
@@ -115,7 +117,7 @@ namespace Helsenorge.Registries.Abstractions
         {
             if (string.IsNullOrEmpty(messageName)) throw new ArgumentNullException(nameof(messageName));
 
-            return Roles.SelectMany(role => role.ReceiveMessages).FirstOrDefault(message => message.Name.Equals(messageName, StringComparison.Ordinal));
+            return Roles.FirstOrDefault(role => role.ProcessSpecification.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase)).ReceiveMessages.FirstOrDefault();
         }
 
     

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Registries.xml</DocumentationFile>
-    <Version>3.0.4-beta05</Version>
+    <Version>3.0.4-beta06</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -96,7 +96,7 @@ namespace Helsenorge.Registries.Tests
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
             Assert.AreEqual(profile.CpaId, Guid.Empty);
             Assert.AreEqual("Digitale innbyggertjenester", profile.Name);
-            Assert.AreEqual(14, profile.Roles.Count);
+            Assert.AreEqual(15, profile.Roles.Count);
             Assert.IsNotNull(profile.SignatureCertificate);
             Assert.IsNotNull(profile.EncryptionCertificate);
 
@@ -206,6 +206,14 @@ namespace Helsenorge.Registries.Tests
             Assert.IsNotNull(profile.FindMessageForSender("DIALOG_INNBYGGER_EKONTAKT"));
         }
         [TestMethod]
+        public void FindMessageForSender_Found_Ny_CPP()
+        {
+            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
+            var collaborationProtocolMessage = profile.FindMessageForReceiver("DIALOG_INNBYGGER_BEHANDLEROVERSIKT");
+            Assert.IsNotNull(collaborationProtocolMessage);
+            Assert.AreEqual("Svar", collaborationProtocolMessage.Name);
+        }
+        [TestMethod]
         public void FindMessageForSender_NotFound()
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
@@ -223,6 +231,14 @@ namespace Helsenorge.Registries.Tests
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
             Assert.IsNotNull(profile.FindMessageForReceiver("DIALOG_INNBYGGER_EKONTAKT"));
+        }
+        [TestMethod]
+        public void FindMessageForReceiver_Found_Ny_CPP()
+        {
+            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
+            var collaborationProtocolMessage = profile.FindMessageForSender("DIALOG_INNBYGGER_BEHANDLEROVERSIKT");
+            Assert.IsNotNull(collaborationProtocolMessage);
+            Assert.AreEqual("Hent", collaborationProtocolMessage.Name);
         }
         [TestMethod]
         public void FindMessageForReceiver_NotFound()

--- a/test/Helsenorge.Registries.Tests/Files/CPP_93238.xml
+++ b/test/Helsenorge.Registries.Tests/Files/CPP_93238.xml
@@ -36,6 +36,26 @@
             </tns:ServiceBinding>
         </tns:CollaborationRole>
         <tns:CollaborationRole>
+          <tns:ProcessSpecification tns:name="Dialog_Innbygger_BehandlerOversikt" tns:version="1.0" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes/Dialog_Innbygger_behandlerOversikt.xml" tns:uuid="b86b0d41-21fd-4ab7-86f3-af633ea7b27a" />
+          <tns:Role tns:name="Innbygger" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes#Innbygger" />
+          <tns:ApplicationCertificateRef tns:certId="enc" />
+          <tns:ServiceBinding>
+            <tns:Service tns:type="string">BehandlerOversikt</tns:Service>
+            <tns:CanSend>
+              <tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Behandler_Hent" tns:action="Hent" tns:packageId="package_dialogmld_v1p1" xlink:type="simple">
+                <tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
+                <tns:ChannelId>AMQPSync_4d060363-b2ce-4427-8c10-3443dfc115c0</tns:ChannelId>
+              </tns:ThisPartyActionBinding>
+            </tns:CanSend>
+            <tns:CanReceive>
+              <tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Svar" tns:action="Svar" tns:packageId="package_dialogmld_v1p1" xlink:type="simple">
+                <tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
+                <tns:ChannelId>AMQPSync_4d060363-b2ce-4427-8c10-3443dfc115c0</tns:ChannelId>
+              </tns:ThisPartyActionBinding>
+            </tns:CanReceive>
+          </tns:ServiceBinding>
+        </tns:CollaborationRole>
+          <tns:CollaborationRole>
             <tns:ProcessSpecification tns:name="Dialog_Innbygger_Digitalbruker" tns:version="1.1" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes/Dialog_Innbygger_Digitalbruker.xml" tns:uuid="2075C7E3-A2E1-40F7-9CC1-52E2AADF4E93" />
             <tns:Role tns:name="DIALOG_INNBYGGER_DIGITALBRUKERsender" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes#DIALOG_INNBYGGER_DIGITALBRUKERsender" />
             <tns:ApplicationCertificateRef tns:certId="enc" />


### PR DESCRIPTION
Methods FindMessageForSender and FindMessageForReceiver failed for the new CPP format resulting in being unable to send messages setup using the new CPP format. Amended these methods to use the ProcessSpecification Name to be able to find the correct CollaborationProtocolMessage.