### PR TITLE
Add Fallback for FindMessageForSender

### DIFF
--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Messaging.xml</DocumentationFile>
     <Product>Helsenorge Messaging</Product>
-    <Version>3.0.4-beta06</Version>
+    <Version>3.0.4-beta07</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Abstractions\IMessageReceiverFactory.cs" />

--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
@@ -98,6 +98,7 @@ namespace Helsenorge.Registries.Abstractions
         /// <summary>
         /// Finds the collaboration information for a specific message
         /// Find using the ProcessSpecification name as this matches the message name in both new and old Cpp formats
+        /// For response messages such as AppRec the ProcessSpecification name is not setup and the receivemessages need to be checked
         /// </summary>
         /// <param name="messageName">i.e. DIALOG_INNBYGER_EKONTAKT, DIALOG_INNBYGGER_KOORDINATOR, etc.</param>
         /// <returns></returns>
@@ -105,11 +106,21 @@ namespace Helsenorge.Registries.Abstractions
         {
             if (string.IsNullOrEmpty(messageName)) throw new ArgumentNullException(nameof(messageName));
 
-            return Roles.FirstOrDefault(role => role.ProcessSpecification.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase)).SendMessages.FirstOrDefault();
+            var messages = Roles.FirstOrDefault(role => role.ProcessSpecification.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase));
+
+            if (messages == null)
+            {
+                return Roles.SelectMany(role => role.SendMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.Ordinal));
+            }
+            else
+            {
+                return messages.SendMessages.FirstOrDefault();
+            }
         }
         /// <summary>
         /// Finds the collaboration information for a specific message
         /// Find using the ProcessSpecification name as this matches the message name in both new and old Cpp formats
+        /// For response messages such as AppRec the ProcessSpecification name is not setup and the receivemessages need to be checked
         /// </summary>
         /// <param name="messageName">i.e. DIALOG_INNBYGER_EKONTAKT, DIALOG_INNBYGGER_KOORDINATOR, etc.</param>
         /// <returns></returns>
@@ -117,10 +128,18 @@ namespace Helsenorge.Registries.Abstractions
         {
             if (string.IsNullOrEmpty(messageName)) throw new ArgumentNullException(nameof(messageName));
 
-            return Roles.FirstOrDefault(role => role.ProcessSpecification.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase)).ReceiveMessages.FirstOrDefault();
+            var messages = Roles.FirstOrDefault(role => role.ProcessSpecification.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase));
+
+            if (messages == null)
+            {
+                return Roles.SelectMany(role => role.ReceiveMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.Ordinal));
+            }
+            else
+            {
+                return messages.ReceiveMessages.FirstOrDefault();
+            }
         }
 
-    
         private IEnumerable<CollaborationProtocolMessagePart> FindMessagePartsForSenderOrReceiverAppRec(string messageName, Func<CollaborationProtocolRole, IList<CollaborationProtocolMessage>> sendOrReceive)
         {
             foreach (var role in Roles)

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Registries.xml</DocumentationFile>
-    <Version>3.0.4-beta06</Version>
+    <Version>3.0.4-beta07</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -206,6 +206,12 @@ namespace Helsenorge.Registries.Tests
             Assert.IsNotNull(profile.FindMessageForSender("DIALOG_INNBYGGER_EKONTAKT"));
         }
         [TestMethod]
+        public void FindMessageForSender_Found_AppRec()
+        {
+            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
+            Assert.IsNotNull(profile.FindMessageForSender("APPREC"));
+        }
+        [TestMethod]
         public void FindMessageForSender_Found_Ny_CPP()
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
@@ -231,6 +237,12 @@ namespace Helsenorge.Registries.Tests
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
             Assert.IsNotNull(profile.FindMessageForReceiver("DIALOG_INNBYGGER_EKONTAKT"));
+        }
+        [TestMethod]
+        public void FindMessageForReceiver_Found_AppRec()
+        {
+            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
+            Assert.IsNotNull(profile.FindMessageForReceiver("APPREC"));
         }
         [TestMethod]
         public void FindMessageForReceiver_Found_Ny_CPP()


### PR DESCRIPTION
AppRec messages are not getting sent because they do not have a ProcessSpecification so the CollaborationProtocolProfile (CPP) needs to be found using a different method. This reverts to the old method of finding the CPP if it cannot be found using the ProcessSpecification.