### PR TITLE
feature: ICertificateStore abstraction

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/ICertificateStore.cs
+++ b/src/Helsenorge.Messaging/Abstractions/ICertificateStore.cs
@@ -1,0 +1,16 @@
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace Helsenorge.Messaging.Abstractions
+{
+    /// <summary>
+    /// Abstraction for the certificate store
+    /// </summary>
+    public interface ICertificateStore
+    {
+        /// <summary>
+        /// Returns a certificate from a certificate store
+        /// </summary>
+        /// <returns></returns>
+        X509Certificate2 GetCertificate(string thumbprint);
+    }
+}

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Messaging.xml</DocumentationFile>
     <Product>Helsenorge Messaging</Product>
-    <Version>3.0.4</Version>
+    <Version>3.1.0-alpha01</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Abstractions\IMessageReceiverFactory.cs" />

--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -6,7 +6,16 @@ using Helsenorge.Messaging.ServiceBus.Senders;
 using Helsenorge.Registries.Abstractions;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Helsenorge.Messaging.Tests, PublicKey=00240000048" + 
+                              "0000094000000060200000024000052534131000400000100" +
+                              "0100773d7b513076df908a05edadb53a26effc169310d844f" +
+                              "f47ed842bebef258bcfda39e2c62e4d6ceabb04037a24bcd2" +
+                              "85efd882ee7623170664411d5f5107cd2756221ba572b4903" +
+                              "bd45153c192cae7c544ea23b88f814c49a4709218355eac93" +
+                              "98524c353f4a5678ea9a2755bb012707d2de25019af5fd511" +
+                              "b1f48aa5a6eadd4")]
 namespace Helsenorge.Messaging
 {
     /// <summary>
@@ -23,10 +32,12 @@ namespace Helsenorge.Messaging
         /// <param name="settings">Set of options to use</param>
         /// <param name="collaborationProtocolRegistry">Reference to the collaboration protocol registry</param>
         /// <param name="addressRegistry">Reference to the address registry</param>
+        /// <param name="certificateStore">Reference to a certificate store</param>
         public MessagingClient(
             MessagingSettings settings,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry)
+            IAddressRegistry addressRegistry,
+            ICertificateStore certificateStore = null) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore)
         {
             _asynchronousServiceBusSender = new AsynchronousSender(ServiceBus);
             _synchronousServiceBusSender = new SynchronousSender(ServiceBus);

--- a/src/Helsenorge.Messaging/MessagingCore.cs
+++ b/src/Helsenorge.Messaging/MessagingCore.cs
@@ -4,7 +4,6 @@ using Helsenorge.Messaging.Security;
 using Helsenorge.Messaging.ServiceBus;
 using Helsenorge.Registries;
 using Helsenorge.Registries.Abstractions;
-using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Messaging
 {
@@ -25,6 +24,12 @@ namespace Helsenorge.Messaging
         /// Provides access to the address registry
         /// </summary>
         internal IAddressRegistry AddressRegistry { get; }
+
+        /// <summary>
+        /// Returns the current CertificateStore
+        /// </summary>
+        internal ICertificateStore CertificateStore { get;  }
+
         /// <summary>
         /// Gets or sets the default <see cref="ICertificateValidator"/>.The default implementation is <see cref="CertificateValidator"/>
         /// </summary>
@@ -38,18 +43,25 @@ namespace Helsenorge.Messaging
         /// </summary>
         public ServiceBusCore ServiceBus { get; }
 
+        internal ICertificateStore GetDefaultCertificateStore()
+        {
+            return new WindowsCertificateStore(Settings.SigningCertificate?.StoreName, Settings.SigningCertificate?.StoreLocation);
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="settings">Set of options to use</param>
         /// <param name="collaborationProtocolRegistry">Reference to the collaboration protocol registry</param>
         /// <param name="addressRegistry">Reference to the address registry</param>
+        /// <param name="certificateStore"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         protected MessagingCore(
             MessagingSettings settings,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry)
+            IAddressRegistry addressRegistry,
+            ICertificateStore certificateStore = null)
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
             if (collaborationProtocolRegistry == null) throw new ArgumentNullException(nameof(collaborationProtocolRegistry));
@@ -58,6 +70,8 @@ namespace Helsenorge.Messaging
             Settings = settings;
             CollaborationProtocolRegistry = collaborationProtocolRegistry;
             AddressRegistry = addressRegistry;
+
+            CertificateStore = certificateStore ?? GetDefaultCertificateStore();
 
             DefaultCertificateValidator = new CertificateValidator(settings.UseOnlineRevocationCheck);
             DefaultMessageProtection = new SignThenEncryptMessageProtection();

--- a/src/Helsenorge.Messaging/MessagingServer.cs
+++ b/src/Helsenorge.Messaging/MessagingServer.cs
@@ -45,12 +45,14 @@ namespace Helsenorge.Messaging
         /// <param name="loggerFactory">Logger Factory</param>
         /// <param name="collaborationProtocolRegistry">Reference to the collaboration protocol registry</param>
         /// <param name="addressRegistry">Reference to the address registry</param>
+        /// <param name="certificateStore">Reference to a certificate store</param>
         public MessagingServer(
             MessagingSettings settings,
             ILogger logger,
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry)
+            IAddressRegistry addressRegistry,
+            ICertificateStore certificateStore = null) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore)
         {
             if (logger == null) throw new ArgumentNullException(nameof(logger));
             if (loggerFactory == null) throw new ArgumentNullException(nameof(loggerFactory));

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using Microsoft.ServiceBus.Management;
-using Helsenorge.Registries.Abstractions;
 
 namespace Helsenorge.Messaging
 {
@@ -242,8 +240,6 @@ namespace Helsenorge.Messaging
     /// </summary>
     public class CertificateSettings
     {
-        X509Certificate2 _certificate;
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -264,33 +260,5 @@ namespace Helsenorge.Messaging
         /// The location of the certificate store to use
         /// </summary>
         public StoreLocation StoreLocation { get; set; }
-
-        /// <summary>
-        /// Gets the actual certificate specified by the configuration
-        /// </summary>
-        public X509Certificate2 Certificate
-        {
-            get
-            {
-                if (_certificate != null) return _certificate;
-
-                var store = new X509Store(StoreName, StoreLocation);
-                store.Open(OpenFlags.ReadOnly);
-                var certCollection = store.Certificates.Find(X509FindType.FindByThumbprint, Thumbprint, false);
-                var enumerator = certCollection.GetEnumerator();
-                X509Certificate2 cert = null;
-                while (enumerator.MoveNext())
-                {
-                    cert = enumerator.Current;
-                }
-                store.Close();
-                _certificate = cert;
-                return _certificate;
-            }
-            set
-            {
-                _certificate = value;
-            }
-        }
     }
 }

--- a/src/Helsenorge.Messaging/Security/WindowsCertificateStore.cs
+++ b/src/Helsenorge.Messaging/Security/WindowsCertificateStore.cs
@@ -1,0 +1,50 @@
+﻿using Helsenorge.Messaging.Abstractions;
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Helsenorge.Messaging.Security
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    internal class WindowsCertificateStore : ICertificateStore
+    {
+        private readonly StoreName? _storeName;
+        private readonly StoreLocation? _storeLocation;
+
+        /// <summary>
+        /// Retrieves a certificate from the Windows Certificate Store
+        /// </summary>
+        /// <param name="storeName"></param>
+        /// <param name="storeLocation"></param>
+        public WindowsCertificateStore(StoreName? storeName, StoreLocation? storeLocation)
+        {
+            _storeName = storeName ?? throw new ArgumentNullException(nameof(storeName));
+            _storeLocation = storeLocation ?? throw new ArgumentNullException(nameof(storeLocation));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="thumbprint"></param>
+        /// <returns></returns>
+        public X509Certificate2 GetCertificate(string thumbprint)
+        {
+            if (string.IsNullOrEmpty(thumbprint)) throw new ArgumentException($"Argument '{nameof(thumbprint)}' must contain a value.", nameof(thumbprint));
+
+            var store = new X509Store(_storeName.Value, _storeLocation.Value);
+            store.Open(OpenFlags.ReadOnly);
+
+            var certCollection = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, false);
+            var enumerator = certCollection.GetEnumerator();
+            X509Certificate2 certificate = null;
+            while (enumerator.MoveNext())
+            {
+                certificate = enumerator.Current;
+            }
+            store.Close();
+            
+            return certificate;
+        }
+    }
+}

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -284,9 +284,9 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                 // in receive mode, we try to decrypt and validate content even if the certificates are invalid
                 // invalid certificates are flagged to the application layer processing the decrypted message.
                 // with the decrypted content, they may have a chance to figure out who sent it
-                var decryption = Core.Settings.DecryptionCertificate.Certificate;
+                var decryption = Core.CertificateStore.GetCertificate(Core.Settings.DecryptionCertificate.Thumbprint);
                 var signature = incomingMessage.CollaborationAgreement?.SignatureCertificate;
-                var legacyDecryption = Core.Settings.LegacyDecryptionCertificate?.Certificate;
+                var legacyDecryption = Core.Settings.LegacyDecryptionCertificate == null ? null : Core.CertificateStore.GetCertificate(Core.Settings.LegacyDecryptionCertificate.Thumbprint);
 
                 incomingMessage.DecryptionError = Core.DefaultCertificateValidator.Validate(decryption, X509KeyUsageFlags.DataEncipherment);
                 ReportErrorOnLocalCertificate(originalMessage, decryption, incomingMessage.DecryptionError, true);

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -52,6 +52,7 @@ namespace Helsenorge.Messaging.ServiceBus
         internal ICertificateValidator DefaultCertificateValidator => Core.DefaultCertificateValidator;
         internal IMessageProtection DefaultMessageProtection => Core.DefaultMessageProtection;
         internal bool LogPayload => Core.Settings.LogPayload;
+        internal ICertificateStore CertificateStore => Core.CertificateStore;
         /// <summary>
         /// Reference to the core messaging system
         /// </summary>
@@ -113,7 +114,7 @@ namespace Helsenorge.Messaging.ServiceBus
                 hasAgreement = false; // if we don't have an agreement, we try to find the specific profile
                 profile = await CollaborationProtocolRegistry.FindProtocolForCounterpartyAsync(logger, outgoingMessage.ToHerId).ConfigureAwait(false);
             }
-            var signature = Settings.SigningCertificate.Certificate;
+            var signature = Core.CertificateStore.GetCertificate(Core.Settings.SigningCertificate.Thumbprint);
             var encryption = profile.EncryptionCertificate;
 
             var validator = Core.DefaultCertificateValidator;

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Registries.xml</DocumentationFile>
-    <Version>3.0.4</Version>
+    <Version>3.1.0-alpha01</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -8,6 +8,8 @@
     <Authors>Direktoratet for e-helse</Authors>
     <Company>Direktoratet for e-helse</Company>
     <Copyright>Direktoratet for e-helse</Copyright>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <DefineConstants>NET46</DefineConstants>

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockCertificateStore.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockCertificateStore.cs
@@ -1,0 +1,34 @@
+﻿using Helsenorge.Messaging.Abstractions;
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Helsenorge.Messaging.Tests.Mocks
+{
+    public class MockCertificateStore : ICertificateStore
+    {
+        public X509Certificate2 GetCertificate(string thumbprint)
+        {
+            X509Certificate2 certificate = null;
+            switch (thumbprint)
+            {
+                case "be26ea7a3eb54e7b00c55782304765777f854192":
+                    certificate = TestCertificates.HelsenorgePrivateEncryptionInvalidStart;
+                    break;
+                case "be26ea7a3eb54e7b00c55782304765777f854191":
+                    certificate = TestCertificates.HelsenorgePrivateEncryptionInvalidEnd;
+                    break;
+                case "fddbcfbb3231f0c66ee2168358229d3cac95e88a":
+                    certificate = TestCertificates.HelsenorgePrivateEncryption;
+                    break;
+                case "bd302b20fcdcf3766bf0bcba485dfb4b2bfe1379":
+                    certificate = TestCertificates.HelsenorgePrivateSigntature;
+                    break;
+                case "b1fae38326a6cefa72708f7633541262e8633b2c":
+                    certificate = TestCertificates.CounterpartyPrivateEncryption;
+                    break;
+            }
+
+            return certificate;
+        }
+    }
+}

--- a/test/Helsenorge.Messaging.Tests/OptionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/OptionTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Helsenorge.Messaging.Security;
+using Helsenorge.Messaging.Tests.Mocks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Helsenorge.Messaging.Tests
@@ -7,6 +10,36 @@ namespace Helsenorge.Messaging.Tests
     [TestClass]
     public class OptionTests : BaseTest
     {
+        [TestMethod]
+        public void MessagingClient_DefaultCerificateStoreIsWindowsCerificateStore()
+        {
+            MessagingClient messagingClient = new MessagingClient(Settings, CollaborationRegistry, AddressRegistry);
+            Assert.IsInstanceOfType(messagingClient.CertificateStore, typeof(WindowsCertificateStore));
+        }
+
+        [TestMethod]
+        public void MessagingServer_DefaultCerificateStoreIsWindowsCerificateStore()
+        {
+            LoggerFactory loggerFactory = new LoggerFactory();
+            MessagingServer messagingServer = new MessagingServer(Settings, loggerFactory.CreateLogger("Mock"), loggerFactory, CollaborationRegistry, AddressRegistry);
+            Assert.IsInstanceOfType(messagingServer.CertificateStore, typeof(WindowsCertificateStore));
+        }
+
+        [TestMethod]
+        public void MessagingClient_CerificateStoreIsMockCerificateStore()
+        {
+            MessagingClient messagingClient = new MessagingClient(Settings, CollaborationRegistry, AddressRegistry, new MockCertificateStore());
+            Assert.IsInstanceOfType(messagingClient.CertificateStore, typeof(MockCertificateStore));
+        }
+
+        [TestMethod]
+        public void MessagingServer_CerificateStoreIsMockCerificateStore()
+        {
+            LoggerFactory loggerFactory = new LoggerFactory();
+            MessagingServer messagingServer = new MessagingServer(Settings, loggerFactory.CreateLogger("Mock"), loggerFactory, CollaborationRegistry, AddressRegistry, new MockCertificateStore());
+            Assert.IsInstanceOfType(messagingServer.CertificateStore, typeof(MockCertificateStore));
+        }
+
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void Options_NotSet()

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
@@ -64,14 +64,14 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         {
             Exception receiveException = null;
 
-            Client = new MessagingClient(Settings, CollaborationRegistry, AddressRegistry)
+            Client = new MessagingClient(Settings, CollaborationRegistry, AddressRegistry, new MockCertificateStore())
             {
                 DefaultMessageProtection = new SignThenEncryptMessageProtection(),   // disable protection for most tests
                 DefaultCertificateValidator = CertificateValidator
             };
             Client.ServiceBus.RegisterAlternateMessagingFactory(MockFactory);
             
-            Server = new MessagingServer(Settings, Logger, LoggerFactory, CollaborationRegistry, AddressRegistry)
+            Server = new MessagingServer(Settings, Logger, LoggerFactory, CollaborationRegistry, AddressRegistry, new MockCertificateStore())
             {
                 DefaultMessageProtection = new SignThenEncryptMessageProtection(),   // disable protection for most tests
                 DefaultCertificateValidator = CertificateValidator
@@ -512,11 +512,11 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         {
             Settings.DecryptionCertificate = new CertificateSettings()
             {
-                Certificate = TestCertificates.CounterpartyPrivateEncryption
+                Thumbprint = "b1fae38326a6cefa72708f7633541262e8633b2c"
             };
             Settings.LegacyDecryptionCertificate = new CertificateSettings()
             {
-                Certificate =  TestCertificates.HelsenorgePrivateEncryption
+                Thumbprint = "fddbcfbb3231f0c66ee2168358229d3cac95e88a"
             };
 
             // postition of arguments have been reversed so that we instert the name of the argument without getting a resharper indication

--- a/test/Helsenorge.Messaging.Tests/WindowsCertificateStoreTests.cs
+++ b/test/Helsenorge.Messaging.Tests/WindowsCertificateStoreTests.cs
@@ -1,0 +1,33 @@
+﻿using Helsenorge.Messaging.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Helsenorge.Messaging.Tests
+{
+    [TestClass]
+    public class WindowsCertificateStoreTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void WindowsCertificateStore_ctor_MissingStoreName_ExpectedArgumentNullException()
+        {
+            new WindowsCertificateStore(null, StoreLocation.LocalMachine);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void WindowsCertificateStore_ctor_MissingStoreLocation_ExpectedArgumentNullException()
+        {
+            new WindowsCertificateStore(StoreName.My, null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void WindowsCertificateStore_GetCertificate_ArgumentThumbprintIsStringEmpty_ExpectedArgumentException()
+        {
+            var store = new WindowsCertificateStore(StoreName.My, StoreLocation.LocalMachine);
+            store.GetCertificate(string.Empty);
+        }
+    }
+}

--- a/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
+++ b/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
@@ -7,7 +7,9 @@
     <ProjectGuid>{0DD35E31-7384-4F3D-BBE0-366993DC2307}</ProjectGuid>
     <Authors>Direktoratet for e-helse</Authors>
     <Company>Direktoratet for e-helse</Company>
-    <Copyright>Direktoratet for e-helse</Copyright>                
+    <Copyright>Direktoratet for e-helse</Copyright>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">


### PR DESCRIPTION
* An interface, ICertifcateStore, so that a client can override the
  default Certification Store which is Windows Certificate Store.
* If ICertificateStore is not set by the client the library will default
  to Widows Certificate Store.
* #46