### PR TITLE
Obsolete Certificate in MessagingSettings

### DIFF
--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Messaging.xml</DocumentationFile>
     <Product>Helsenorge Messaging</Product>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0-beta02</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Abstractions\IMessageReceiverFactory.cs" />

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -242,6 +242,8 @@ namespace Helsenorge.Messaging
     /// </summary>
     public class CertificateSettings
     {
+        X509Certificate2 _certificate;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -262,6 +264,35 @@ namespace Helsenorge.Messaging
         /// The location of the certificate store to use
         /// </summary>
         public StoreLocation StoreLocation { get; set; }
+
+        /// <summary>
+        /// Gets the actual certificate specified by the configuration
+        /// </summary>
+        [Obsolete("This property is deprecated and is kept for backwards compatibility. Use ICertificateStore to get the Certificate")]
+        public X509Certificate2 Certificate
+        {
+            get
+            {
+                if (_certificate != null) return _certificate;
+
+                var store = new X509Store(StoreName, StoreLocation);
+                store.Open(OpenFlags.ReadOnly);
+                var certCollection = store.Certificates.Find(X509FindType.FindByThumbprint, Thumbprint, false);
+                var enumerator = certCollection.GetEnumerator();
+                X509Certificate2 cert = null;
+                while (enumerator.MoveNext())
+                {
+                    cert = enumerator.Current;
+                }
+                store.Close();
+                _certificate = cert;
+                return _certificate;
+            }
+            set
+            {
+                _certificate = value;
+            }
+        }
 
         public void Validate()
         {

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\tools\key.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Helsenorge.Registries.xml</DocumentationFile>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0-beta02</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">


### PR DESCRIPTION
Certificate has been obsoleted in MessagingSettings as this should no
longer be used. You can get the certificate from ICertificateStore.
It has a implementation WindowsCertificateStore that can be used.